### PR TITLE
Added Log Header

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module gopkg.in/natefinch/lumberjack.v2
+module github.com/ArmanPasha/lumberjack
 
 go 1.13

--- a/lumberjack.go
+++ b/lumberjack.go
@@ -3,7 +3,7 @@
 // Note that this is v2.0 of lumberjack, and should be imported using gopkg.in
 // thusly:
 //
-//   import "gopkg.in/natefinch/lumberjack.v2"
+//	import "gopkg.in/natefinch/lumberjack.v2"
 //
 // The package name remains simply lumberjack, and the code resides at
 // https://github.com/natefinch/lumberjack under the v2.0 branch.
@@ -66,7 +66,7 @@ var _ io.WriteCloser = (*Logger)(nil)
 // `/var/log/foo/server.log`, a backup created at 6:30pm on Nov 11 2016 would
 // use the filename `/var/log/foo/server-2016-11-04T18-30-00.000.log`
 //
-// Cleaning Up Old Log Files
+// # Cleaning Up Old Log Files
 //
 // Whenever a new logfile gets created, old log files may be deleted.  The most
 // recent files according to the encoded timestamp will be retained, up to a
@@ -106,6 +106,10 @@ type Logger struct {
 	// Compress determines if the rotated log files should be compressed
 	// using gzip. The default is not to perform compression.
 	Compress bool `json:"compress" yaml:"compress"`
+
+	// Header is a string that will be written as the first line in every log file
+	// leave empty for no header
+	Header string `json:"header" yaml:"header"`
 
 	size int64
 	file *os.File
@@ -238,6 +242,18 @@ func (l *Logger) openNew() error {
 	}
 	l.file = f
 	l.size = 0
+	if l.Header != "" {
+		if int64(len(l.Header)) > l.max() {
+			return fmt.Errorf(
+				"header length %d exceeds maximum file size %d", len(l.Header), l.max(),
+			)
+		}
+		n, err := l.file.Write([]byte(l.Header))
+		if err != nil {
+			return err
+		}
+		l.size += int64(n)
+	}
 	return nil
 }
 


### PR DESCRIPTION
added a new field to the Logger struct that allows writing a fixed header to the log files as the first line. This is mainly useful for formats like CSV, so we can analyze each file separately.